### PR TITLE
first time page updated to match better this season's system.

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -24,5 +24,6 @@
 	"404_title": " could not be found :(",
 	"404_p1": "The provided name might contain a typo or correspond to a summoner not from EUW. This issue might be due to an internal issue though.",
 	"firstTime_welcome": "Welcome ",
-	"firstTime_p1": "You have been registered to the awesome ALL RANDOM ALL RANK! From now on, your ARAM games will be used as part of an unofficial ranking system that I personally made... Will you manage to reach the Challenger league?"
+	"firstTime_p1": "You have been registered to the awesome ALL RANDOM ALL RANK! From now on, you are part of an unofficial ranking system that I personally made... Will you manage to reach the Challenger league?",
+	"clickHere2Reload": "Click here to check your rank!"
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -22,7 +22,8 @@
 	"Bronze V": "Bronze V",
 	"mail": "Le%20 Couscous&body=J'aime%20le%20couscous.",
 	"firstTime_welcome": "Bienvenue ",
-	"firstTime_p1": "Vous avez été inscrit au magnifique système ALL RANDOM ALL RANK ! A partir de maintenant vos parties d'ARAM seront comptabilisées dans un classement officieux conçu par mes soins... Parviendrez vous à atteindre la ligue challenger ?",
+	"firstTime_p1": "Vous avez été inscrit au magnifique système ALL RANDOM ALL RANK ! Vous faites désormais partie d'un classement officieux conçu par mes soins... Parviendrez vous à atteindre la ligue challenger ?",
 	"404_title": "n'a pas été trouvé :(",
-	"404_p1": "Le nom d'invocateur est erroné ou provient d'une autre région que EUW. (possiblement un problème interne)"
+	"404_p1": "Le nom d'invocateur est erroné ou provient d'une autre région que EUW. (possiblement un problème interne)",
+	"clickHere2Reload": "Cliquez ici pour voir votre rang !"
 }

--- a/views/first_time.ejs
+++ b/views/first_time.ejs
@@ -12,6 +12,7 @@
     <h1>
       <img src="/ddragonData/img/profileicon/<%= sum.profileIconId %>.png" width="80px" height="80px"><%= __('firstTime_welcome') %> <%= sum.name %></h1>
       <p><%= __('firstTime_p1') %></p>
+      <p><a href="<%= sum.name %>"><%= __('clickHere2Reload') %></a></p>
     </div>
   </div>
 


### PR DESCRIPTION
Users used to need to register themselves to the website before their games were taken into account.
The 'first_time.ejs' page explained that to them when searching their name for the first time.

Now, the system takes all the arams from the season which leads the user to be confused when reading the frist_time page. An update was necessary to better explain and allow them to refresh the page to check their rank.