### PR TITLE
[bug correction] promise.all now called on promise array before calling catch

### DIFF
--- a/server/player.js
+++ b/server/player.js
@@ -53,7 +53,7 @@ async function searchPlayer(req, res) {
 
   if(dbSum == null) {
     dynamo.putNewSummoner(sum);
-    await promises.catch(err => console.error(err, err.stack));
+    await Promise.all(promises).catch(err => console.error(err, err.stack));
     res.render('first_time');
     return;
   } 


### PR DESCRIPTION
I should really use 'use strict'...