### PR TITLE
reducing the costs of AWS -> ladder updated less frequently

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ schedule.scheduleJob('0 0 */2 * * *', async function(){
   console.log(new Date().toISOString() + ' - riot version = ' + process.env.RIOT_VERSION);
 });
 
-schedule.scheduleJob('0 */10 * * * *', function(){
+schedule.scheduleJob('0 */25 * * * *', function(){
   player.updatePlayers().then(players => ladder.updateLadder(players));
 });
 
@@ -157,7 +157,6 @@ async function getLadder(res) {
 
 app.get('*/pico', function(req, res) {
   player.updatePlayers()
-    .then(players => ladder.updateLadder(players))
     .then( () => res.render('pico') );
 })
 

--- a/views/ladder.ejs
+++ b/views/ladder.ejs
@@ -28,8 +28,8 @@
   let x = setInterval(() => {
     let now = new Date().getTime();
 
-    //ladder updated every 10 minutes <=> 600 000 milliseconds
-    let timeLeft = 600000 - now%600000;
+    //ladder updated every 25 minutes <=> 1 800 000 milliseconds
+    let timeLeft = 1800000 - now%1800000;
     timeLeft /= 1000;
     document.getElementById('ladderTimer').innerHTML = 
       Math.floor(timeLeft/60)


### PR DESCRIPTION
Ladder now updates automatically every 25 min instead of 10 and requesting /pico doesn't update the ladder anymore.