### PR TITLE
Bug correction - Now using ConsistentRead parameter to avoid duplication in match history

### DIFF
--- a/server/dynamo.js
+++ b/server/dynamo.js
@@ -19,7 +19,8 @@ function getSumBySummonerId(id) {
 	     S: id
 	    }
 	  }, 
-	  TableName: table_name
+	  TableName: table_name,
+    ConsistentRead: true,
 	};
 
 
@@ -142,6 +143,7 @@ async function getAllUsers() {
 function recScan(prevData, lastEvaluatedKey) {
   var params = { 
     TableName: table_name,
+    ConsistentRead: true,
   };
 
   if(lastEvaluatedKey != null)  //This is not the first scan


### PR DESCRIPTION
Without ConsistentRead, the scan function can sometimes read data ignoring recent modifications.
Because of that, updating a player's history twice in a row could lead to pushing twice the recent games.