### PR TITLE
Correction: current History now contains 20 instead of 19 games

### DIFF
--- a/server/dynamo.js
+++ b/server/dynamo.js
@@ -220,7 +220,7 @@ function limitHistorySize(sum, oldHistorySize) {
   let spotsLeft = maxHistorySize - oldHistorySize;
   let games2remove = sum.history.length - spotsLeft;
 
-  if(games2remove < 0) {
+  if(games2remove <= 0) {
     return;
   }
 


### PR DESCRIPTION
if precisely 0 games to remove => correctly removes 0 (instead of 1)