### PR TITLE
Correction: corrected the 0->100LP issue causing an unwwanted BO to start

### DIFF
--- a/server/league.js
+++ b/server/league.js
@@ -118,7 +118,11 @@ function demoteLP(league) {
 function demoteUpdate(win, sum, lp) {
   if(win) {
     sum.rank.bo = "ooo";
-    sum.rank.lp = +sum.rank.lp + lp; //manage the string number
+    if(needPromoteBO(sum)) {
+      slowClimbing(sum, lp);
+    } else {
+      fastClimbing(sum, lp);
+    }
     return;
   }
 


### PR DESCRIPTION
When the player has 0lp, he is considered on a losing BO. He has to win one game to get out of it. Winning 100LP or more wasn't promoting the player and thus he was considered in promote BO (because he was at maxLP)